### PR TITLE
Do not use shell=True for opening processes and improve error handling

### DIFF
--- a/configs/example_cfg.toml
+++ b/configs/example_cfg.toml
@@ -9,22 +9,14 @@ modules_root = '../'                                                            
     port = 8081                                                                 # if no port is provided, a random free port is chosen
     ip = '127.0.0.1'
 [python.modules.dp-mockup-streamer.kwargs]                               # kwargs to run the main script with
-    lsl_out_stream_name = 'mockup_EEG_stream'
-    random_data = true       # --> use the start random button!
+    stream_name = 'mockup_EEG_stream'
 
 # -------------------- Pass through decoding -> add a callback ----------------
 [python.modules.dp-passthrough]                                      # names of a module to be used (folder name)
     type = 'pass_through'
     port = 8083                                                                 # if no port is provided, a random free port is chosen
     ip = '127.0.0.1'
-
-
-[python.modules.dp-echo]                                      # names of a module to be used (folder name)
-    type = 'echo'
-    port = 8082                                                                 # if no port is provided, a random free port is chosen
-    ip = '127.0.0.1'
-    retry_connection_after_s = 2                                                # For modules with a slow start-up time, you might want to increase the time between conncetion attempts, default is 1s and 3 connection attempts
-
+    retry_connection_after_s = 1                                                # For modules with a slow start-up time, you might want to increase the time between conncetion attempts, default is 1s and 3 connection attempts
 
 [macros]
 

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -126,8 +127,9 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
 
     connections = []
     log_server = psutil.Process(
-        subprocess.Popen("python -m control_room.utils.logserver", shell=True).pid
+        subprocess.Popen([sys.executable, "-m", "control_room.utils.logserver"]).pid
     )
+
     cbb_th = None
 
     try:

--- a/control_room/processes.py
+++ b/control_room/processes.py
@@ -1,7 +1,7 @@
 import subprocess
 import time
 from pathlib import Path
-from sys import platform
+from sys import executable
 
 import psutil
 
@@ -88,16 +88,21 @@ def start_container(
 
     logger.info(f"Spawning {module_name=} @ {ip}:{port} with {start_kwargs=}")
 
-    cmd = (
-        f"cd {modpath.resolve()}{COMMAND_SEP_MAP[platform]} "
-        "python -m api.server "
-        f"--port={port} --ip={ip} --loglevel={loglevel}"
-        + " "
-        + " ".join([f"--{k}={v}" for k, v in start_kwargs.items()])
-    )
+    cmd = [
+        executable,
+        "-m",
+        "api.server",
+        f"--port={port}",
+        f"--ip={ip}",
+        f"--loglevel={loglevel}",
+        *[f"--{k}={v}" for k, v in start_kwargs.items()],
+    ]
 
     # For now, this just starts python containers
     # [ ] TODO implement this for general containers, including Docker
 
     logger.debug(f"Running Popen with {cmd=}")
-    return subprocess.Popen(cmd, shell=True)
+    return subprocess.Popen(
+        cmd,
+        cwd=str(modpath.resolve()),
+    )

--- a/control_room/socket.py
+++ b/control_room/socket.py
@@ -43,7 +43,7 @@ def create_socket_client(
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.connect((host_ip, port))
             logger.debug(f"Connected to: {host_ip=}, {port=} using {s=}")
-            break
+            return s
         except ConnectionRefusedError:
             logger.debug(f"Connection refused: {host_ip=}, {port=}, try={conn_try + 1}")
 
@@ -55,4 +55,6 @@ def create_socket_client(
             pass
         conn_try += 1
 
-    return s
+    raise ConnectionRefusedError(
+        f"Connection refused after {MAX_CONNECT_RETRIES} tries: {host_ip=}, {port=}"
+    )


### PR DESCRIPTION
This PR should ensure that opening and closing the processes happens as correctly and if not, with clear error messages.

- shell=True is removed both for the logger and in start_container used for other processes. To ensure this works as expected, sys.executable is used instead of plain "python", to ensure the right python is used.
- There were some small bugs in create_socket_client and close_child_processes which this PR fixes. There are also several improvements to error handling and more helpful error messages relating to opening/closing of processes.
- The example_cfg has been updated to work correctly. Some of the kwargs were presumably outdated.

@matthiasdold Let me know if this solves the problem as desired!