### PR TITLE
Improve and add tests for logging and lifetime management

### DIFF
--- a/control_room/connection.py
+++ b/control_room/connection.py
@@ -46,20 +46,20 @@ class ModuleConnection:
                 port=self.port,
                 retry_connection_after_s=self.retry_connection_after_s,
             )
-        except ConnectionRefusedError as err:
+        except Exception as e:
             # Check if connection failed because host process is not running, if so, give a more specific error
-            if self.host_process.poll() is not None:
+            if self.host_process is not None and self.host_process.poll() is not None:
                 logger.debug(
-                    f"{self.name=}- Cannot connect to socket at {self.ip}:{self.port}. Host process not running."
+                    f"{self.name=}- Cannot connect module {self.name=} at {self.ip}:{self.port}. Host process not running."
                 )
                 raise ConnectionRefusedError(
                     f"Cannot connect to module {self.name=} at {self.ip}:{self.port}. Host process not running."
                 )
             else:
                 logger.debug(
-                    f"{self.name=}- Cannot connect to socket at {self.ip}:{self.port}. Connection refused."
+                    f"{self.name=}- Cannot connect module {self.name=} at {self.ip}:{self.port}. {type(e)}"
                 )
-                raise err
+                raise e
 
         # Time-out as non of the sockets should block indefinitely
         self.socket_c.setblocking(0)

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -1,10 +1,11 @@
+import os
+import signal
 import subprocess
 import sys
 import threading
 import time
-import os
 from pathlib import Path
-import signal
+
 import psutil
 from fire import Fire
 from waitress.server import create_server
@@ -154,7 +155,10 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
 
     connections = []
     log_server = psutil.Process(
-        subprocess.Popen([sys.executable, "-m", "control_room.utils.logserver"], creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == 'nt' else 0).pid
+        subprocess.Popen(
+            [sys.executable, "-m", "control_room.utils.logserver"],
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+        ).pid
     )
 
     time.sleep(0.5)  # give the log server a moment to start
@@ -226,14 +230,14 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
 
         # Register signal handlers for graceful shutdown
         # TODO: test on all platforms
-        signal.signal(signal.SIGBREAK, lambda s,f: on_shutdown())
-        signal.signal(signal.SIGINT, lambda s,f: on_shutdown())
-        signal.signal(signal.SIGTERM, lambda s,f: on_shutdown())
+        signal.signal(signal.SIGBREAK, lambda s, f: on_shutdown())
+        signal.signal(signal.SIGINT, lambda s, f: on_shutdown())
+        signal.signal(signal.SIGTERM, lambda s, f: on_shutdown())
 
         logger.info("Serving control room on port 8050")
         server = create_server(app.server, port=8050)
         server.run()
-        
+
         logger.info("Control room server has stopped.")
 
     finally:
@@ -254,7 +258,7 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
             logger.error(f"Error while closing down connections: {e}")
 
         logger.debug("Terminating log server")
-        time.sleep(1) # give some time to process remaining logs
+        time.sleep(1)  # give some time to process remaining logs
 
         if log_server.is_running():
             try:

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -229,8 +229,9 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
                 server.close()
 
         # Register signal handlers for graceful shutdown
-        # TODO: test on all platforms
-        signal.signal(signal.SIGBREAK, lambda s, f: on_shutdown())
+        # SIGBREAK is Windows-specific
+        if hasattr(signal, "SIGBREAK"):
+            signal.signal(signal.SIGBREAK, lambda s, f: on_shutdown())
         signal.signal(signal.SIGINT, lambda s, f: on_shutdown())
         signal.signal(signal.SIGTERM, lambda s, f: on_shutdown())
 

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -100,7 +100,7 @@ def initialize_exe_modules(mod_cfgs: dict) -> list[ModuleConnection]:
 
     # Exe modules
     for module_name, module_cfg in mod_cfgs["modules"].items():
-        required_keys = ["path", "ip", "port", "pcomms"]
+        required_keys = ["path", "ip", "port"]
         for key in required_keys:
             if key not in module_cfg:
                 raise KeyError(
@@ -113,8 +113,8 @@ def initialize_exe_modules(mod_cfgs: dict) -> list[ModuleConnection]:
                 exe_path=Path(module_cfg["path"]),
                 ip=module_cfg["ip"],
                 port=module_cfg["port"],
-                pcomms=list(module_cfg["pcomms"].keys()),
-                pcomms_defaults=module_cfg["pcomms"],
+                pcomms=list(module_cfg.get("pcomms", {}).keys()),
+                pcomms_defaults=module_cfg.get("pcomms", {}),
             )
         )
 

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -58,6 +58,19 @@ def initialize_python_modules(mod_cfgs: dict) -> list[ModuleConnection]:
     """
     connections = []
 
+    if "modules" not in mod_cfgs:
+        logger.info("No python modules to initialize.")
+        return connections
+
+    if "modules_root" not in mod_cfgs:
+        logger.warning(
+            "No 'modules_root' specified in python module configurations. "
+            f"Using parent directory of current working directory as default ({Path.cwd().parent})."
+        )
+        mod_cfgs["modules_root"] = Path.cwd().parent
+
+    logger.debug(f"Python module configurations found: {mod_cfgs['modules'].keys()}")
+
     # Python modules
     for module_name, module_cfg in mod_cfgs["modules"].items():
         connections.append(
@@ -77,8 +90,21 @@ def initialize_exe_modules(mod_cfgs: dict) -> list[ModuleConnection]:
     """
     connections = []
 
-    # Python modules
+    if "modules" not in mod_cfgs:
+        logger.info("No exe modules to initialize.")
+        return connections
+
+    logger.debug(f"Exe module configurations found: {mod_cfgs['modules'].keys()}")
+
+    # Exe modules
     for module_name, module_cfg in mod_cfgs["modules"].items():
+        required_keys = ["path", "ip", "port", "pcomms"]
+        for key in required_keys:
+            if key not in module_cfg:
+                raise KeyError(
+                    f"Module configuration for {module_name} is missing required key: {key}"
+                )
+
         connections.append(
             ModuleConnectionExe(
                 name=module_name,

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -157,6 +157,9 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
         subprocess.Popen([sys.executable, "-m", "control_room.utils.logserver"], creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == 'nt' else 0).pid
     )
 
+    time.sleep(0.5)  # give the log server a moment to start
+
+    logger.info(f"Opening control room with configuration: {setup_cfg_path}")
     cbb_th = None
     server = None
 
@@ -173,7 +176,7 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
             logger.debug(f"Starting module server for {conn.name=}")
             conn.start_module_server()
 
-        time.sleep(0.5)
+        time.sleep(2)  # give the servers a moment to start
 
         # connect clients to the servers
         for conn in connections:

--- a/control_room/main.py
+++ b/control_room/main.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import threading
 import time
+import os
 from pathlib import Path
 
 import psutil
@@ -153,7 +154,7 @@ def run_control_room(setup_cfg_path: str = setup_cfg_path):
 
     connections = []
     log_server = psutil.Process(
-        subprocess.Popen([sys.executable, "-m", "control_room.utils.logserver"]).pid
+        subprocess.Popen([sys.executable, "-m", "control_room.utils.logserver"], creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == 'nt' else 0).pid
     )
 
     cbb_th = None

--- a/control_room/socket.py
+++ b/control_room/socket.py
@@ -48,10 +48,6 @@ def create_socket_client(
         except ConnectionRefusedError:
             logger.debug(f"Connection refused: {host_ip=}, {port=}, try={conn_try + 1}")
 
-            # Close the socket and start fresh as otherwise
-            # we will get a an Errno 22 in the second try
-            s.close()
-
             if conn_try == MAX_CONNECT_RETRIES - 1:
                 raise ConnectionRefusedError(
                     f"Creating socket failed. Connection refused after {MAX_CONNECT_RETRIES} tries: {host_ip=}, {port=}"
@@ -69,10 +65,6 @@ def create_socket_client(
                 )
         except Exception as e:
             logger.error(f"Unexpected error when creating socket: {e}")
-            try:
-                s.close()
-            except:
-                pass
 
             if conn_try == MAX_CONNECT_RETRIES - 1:
                 raise type(e)(

--- a/control_room/socket.py
+++ b/control_room/socket.py
@@ -8,13 +8,13 @@ MAX_CONNECT_RETRIES = 3
 
 
 def create_socket_client(
-    host_ip: str, port: int, retry_connection_after_s: float = 1
+    host_ip: str, port: int, retry_connection_after_s: float = 1, timeout: float = 0.1
 ) -> socket.socket:
     """
     Create a socket client and attempt to connect to a specified host and port.
 
     This function attempts to establish a TCP connection to the specified host and port.
-    It retries the connection up to a maximum number of times (3) if the connection is refused.
+    It retries the connection up to a maximum number of times (3) if the connection is refused or times out.
     If the connection is successful, the socket object is returned.
 
     Parameters
@@ -25,6 +25,8 @@ def create_socket_client(
         The port number on the host to connect to.
     retry_connection_after_s : float, optional
         The number of seconds to wait between connection attempts, by default 1.
+    timeout : float, optional
+        The timeout duration for the socket connection in seconds, by default 0.1.
 
     Returns
     -------
@@ -40,8 +42,7 @@ def create_socket_client(
     while conn_try < MAX_CONNECT_RETRIES:
         try:
             logger.debug(f"Trying connection to: {host_ip=}, {port=}")
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((host_ip, port))
+            s = socket.create_connection((host_ip, port), timeout=timeout)
             logger.debug(f"Connected to: {host_ip=}, {port=} using {s=}")
             return s
         except ConnectionRefusedError:
@@ -51,10 +52,31 @@ def create_socket_client(
             # we will get a an Errno 22 in the second try
             s.close()
 
+            if conn_try == MAX_CONNECT_RETRIES - 1:
+                raise ConnectionRefusedError(
+                    f"Creating socket failed. Connection refused after {MAX_CONNECT_RETRIES} tries: {host_ip=}, {port=}"
+                )
             time.sleep(retry_connection_after_s)
-            pass
-        conn_try += 1
+        except TimeoutError:
+            logger.debug(
+                f"Connection timed out: {host_ip=}, {port=}, try={conn_try + 1}"
+            )
+            time.sleep(retry_connection_after_s)
 
-    raise ConnectionRefusedError(
-        f"Connection refused after {MAX_CONNECT_RETRIES} tries: {host_ip=}, {port=}"
-    )
+            if conn_try == MAX_CONNECT_RETRIES - 1:
+                raise TimeoutError(
+                    f"Creating socket failed. Connection timed out after {MAX_CONNECT_RETRIES} tries: {host_ip=}, {port=}"
+                )
+        except Exception as e:
+            logger.error(f"Unexpected error when creating socket: {e}")
+            try:
+                s.close()
+            except:
+                pass
+
+            if conn_try == MAX_CONNECT_RETRIES - 1:
+                raise type(e)(
+                    f"Creating socket failed. Unknown error after {MAX_CONNECT_RETRIES} tries: {host_ip=}, {port=}"
+                ) from e
+            time.sleep(retry_connection_after_s)
+        conn_try += 1

--- a/tests/resources/helpers.py
+++ b/tests/resources/helpers.py
@@ -1,0 +1,19 @@
+import socket
+import time
+
+
+def wait_for_port(host: str = "127.0.0.1", port: int = 9020, timeout: float = 5.0):
+    """Wait until a port is open on the given host, or timeout."""
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with socket.socket() as s:
+                s.settimeout(0.5)
+                s.connect((host, port))
+                s.close()
+                return True
+        except OSError as e:
+            last_err = e
+            time.sleep(0.5)
+    raise TimeoutError(f"Port {host}:{port} not ready: {last_err}")

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import threading
 import time
+from typing import Iterator
 
 import psutil
 import pytest
@@ -81,7 +82,7 @@ def test_socket_connection(module_with_thread_for_tserver):
 
 
 @pytest.fixture
-def slow_server_thread() -> tuple[threading.Thread, threading.Event]:
+def slow_server_thread() -> Iterator[tuple[threading.Thread, threading.Event]]:
     sev = threading.Event()
     thread = threading.Thread(
         target=run_slow_startup_server,

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -162,14 +162,8 @@ def test_subprocess(module_connection_with_running_process):
     con.stop_process()
     time.sleep(0.5)
 
-    # Second condition added for testing on windows
-    try:
-        assert con.host_process is None and hostp.status() == "zombie"
-    finally:
+    assert con.host_process is None
+
+    # Process should be killed already, so this should raise NoSuchProcess error
+    with pytest.raises(psutil.NoSuchProcess):
         hostp.kill()
-
-    logger.info(f"{hostp=}")
-
-
-# def test_just_run():
-#     run_server(port=8080, ip="127.0.0.1")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,105 @@
+import logging
+import subprocess
+import sys
+import time
+from socket import socket
+
+import pytest
+from dareplane_utils.logging.logger import get_logger
+from dareplane_utils.logging.ujson_socket_handler import UJsonSocketHandler
+
+from tests.resources.helpers import wait_for_port
+
+
+@pytest.fixture()
+def fresh_logger():
+    """Provide a fresh logger instance for each test with a new UJsonSocketHandler.
+
+    This fixture ensures that the logger used in tests has a fresh UJsonSocketHandler.
+    Usually, loggers share the handler instance, which can lead to interference between tests.
+
+    Yields
+    ------
+    logging.Logger
+    """
+    fresh_logger = get_logger("test_logger")
+    for handler in fresh_logger.handlers[:]:
+        if isinstance(handler, UJsonSocketHandler):
+            # Remove existing UJsonSocketHandler
+            fresh_logger.removeHandler(handler)
+
+    # Add a new UJsonSocketHandler, pointing to the test log server
+    fresh_logger.addHandler(UJsonSocketHandler("127.0.0.1", 9020))
+
+    fresh_logger.setLevel(logging.DEBUG)
+    yield fresh_logger
+
+
+def test_logger_fails_fast(fresh_logger):
+    logger = fresh_logger
+    test_socket = socket()
+    test_socket.settimeout(1)
+
+    # Ensure the log server is not running
+    with pytest.raises(Exception):
+        test_socket.connect(("127.0.0.1", 9020))
+
+    start = time.time()
+    logger.debug("Testing logger fails fast on unreachable server")
+    end = time.time()
+
+    # If the log server is unreachable, the logger should fail fast
+    # The timeout duration is currently defined as 0.1s in dareplane-pyutils/src/dareplane_utils/logging/ujson_socket_handler.py
+    assert end - start < 0.2
+
+    start = time.time()
+    logger.debug("Testing continued logging after failed connection")
+    end = time.time()
+
+    # The socket connection uses an exponential backoff, so subsequent calls within a short time should fail immediately
+    assert end - start < 0.01
+
+
+def test_log_server_socket_connection():
+    # Start the log server process (example command)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "control_room.utils.logserver"],
+    )
+
+    # Try to connect to the log server, fails if not able to connect within timeout
+    wait_for_port("127.0.0.1", 9020, timeout=5.0)
+
+    # Teardown
+    try:
+        proc.terminate()
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def test_logger_logs(fresh_logger):
+    logger = fresh_logger
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "control_room.utils.logserver"],
+    )
+
+    # Wait for the log server to be ready
+    wait_for_port("127.0.0.1", 9020, timeout=5.0)
+
+    # try logging
+    start = time.time()
+    logger.debug("This is test debug message from test_logger")
+    end = time.time()
+
+    # With the log server running, logging should be quick
+    assert end - start < 0.1
+
+    # Teardown
+    time.sleep(
+        1.0
+    )  # give some time for the log to be processed, log does not show up otherwise
+    try:
+        proc.terminate()
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -49,8 +49,8 @@ def test_logger_fails_fast(fresh_logger):
     end = time.time()
 
     # If the log server is unreachable, the logger should fail fast
-    # The timeout duration is currently defined as 0.1s in dareplane-pyutils/src/dareplane_utils/logging/ujson_socket_handler.py
-    assert end - start < 0.2
+    # The timeout duration is currently defined as 0.3s in dareplane-pyutils/src/dareplane_utils/logging/ujson_socket_handler.py
+    assert end - start < 0.4
 
     start = time.time()
     logger.debug("Testing continued logging after failed connection")

--- a/tests/test_module_startup.py
+++ b/tests/test_module_startup.py
@@ -1,0 +1,109 @@
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import tomllib
+
+
+def test_run_control_room():
+    cfg_path = "./configs/example_cfg.toml"
+    cfg = tomllib.load(open(Path(cfg_path), "rb"))
+
+    print("Sys executable:", sys.executable)
+    # Start the control room in a subprocess, capturing stdout and stderr so we can debug if it fails
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "control_room.main", "--setup-cfg-path", cfg_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+    )
+
+    print("Started control room subprocess, PID:", proc.pid)
+    try:
+        # Allow some time for the control room to start
+        time.sleep(20)
+
+        # Check if the subprocess is still running, if not, capture output and raise error
+        rc = proc.poll()
+        if rc is not None:
+            stdout, stderr = proc.communicate()
+            raise AssertionError(
+                f"Subprocess exited early!\n"
+                f"Return code: {rc}\n"
+                f"STDOUT:\n{stdout}\n"
+                f"STDERR:\n{stderr}"
+            )
+
+        # Check that all modules specified in the config are running and reachable
+        for conn_type in ["python", "exe"]:
+            if conn_type in cfg:
+                for module_name in cfg[conn_type]["modules"]:
+                    port = cfg[conn_type]["modules"][module_name]["port"]
+                    ip = cfg[conn_type]["modules"][module_name]["ip"]
+                    # Check if the module port is open
+                    try:
+                        print(
+                            f"Checking connectivity to module {module_name} at {ip}:{port}..."
+                        )
+                        s = socket.create_connection((ip, port), timeout=5)
+                        s.close()
+                    except Exception as e:
+                        raise AssertionError(
+                            f"Module {module_name} at {ip}:{port} is not reachable: {e}"
+                        )
+
+    finally:
+        if proc.poll() is None:
+            print(f"Terminating control room subprocess {proc.pid} ...")
+            proc.send_signal(
+                signal.CTRL_BREAK_EVENT if os.name == "nt" else signal.SIGINT
+            )
+
+            # Wait for I/O, necessary to ensure proper termination
+            stdout, stderr = proc.communicate()
+
+            try:
+                proc.wait(timeout=20)
+            except Exception:
+                print(f"Subprocess {proc.pid} did not terminate in time, killing it.")
+                proc.kill()
+                proc.wait(timeout=20)
+                assert False, (
+                    "Control room subprocess did not terminate gracefully after signal."
+                )
+
+        assert proc.poll() is not None, (
+            "Control room subprocess did not shut down properly."
+        )
+
+        # Check that modules have shut down properly
+        for conn_type in ["python", "exe"]:
+            if conn_type in cfg:
+                for module_name in cfg[conn_type]["modules"]:
+                    port = cfg[conn_type]["modules"][module_name]["port"]
+                    ip = cfg[conn_type]["modules"][module_name]["ip"]
+                    # Check if the module port is open, it should be closed now
+                    with pytest.raises(Exception):
+                        try:
+                            conn = socket.create_connection((ip, port), timeout=0.5)
+                            conn.close()
+                        except Exception as e:
+                            print(
+                                f"Module {module_name} at {ip}:{port} is confirmed shut down."
+                            )
+                            raise e
+
+        # Check that log server has shut down properly
+        log_port = 9020
+        with pytest.raises(Exception):
+            try:
+                conn = socket.create_connection(("127.0.0.1", log_port), timeout=0.5)
+                conn.close()
+            except Exception as e:
+                print(f"Log server at 127.0.0.1:{log_port} is confirmed shut down.")
+                raise e


### PR DESCRIPTION
This PR mainly does two things:
- Ensure that control_room.main gracefully shuts down as expected, including shutting down other modules and the log server (@matthiasdold can you confirm that it is the intended behaviour that all connected modules are closed when the control_room is closed?).
- Add and improve tests. Some existing tests were failing and are now fixed. Furthermore, tests are added for logging and to check whether the control_room.main starts and shuts down correctly.

All tests currently pass on my windows installation, but I will check if it works on Ubuntu soon.

The `test_logger_fails_fast` tests depends on https://github.com/matthiasdold/dareplane-pyutils/pull/2, which implements the behaviour that connection attempts to the log server fail fast.