### PR TITLE
Add github action to build and run tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,8 +37,7 @@ jobs:
           set -euxo pipefail
           python -m pip install --upgrade pip
           python -m pip install flake8 pytest
-          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
-          python -m pip install -e .
+          if [ -f tests_requirements.txt ]; then python -m pip install -r tests_requirements.txt; fi
 
       - name: Install liblsl (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,103 @@
+name: Python application
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+env:
+  LIBLSL_VERSION: "1.17.5"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install flake8 pytest
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          python -m pip install -e .
+
+      - name: Install liblsl (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME:-}")"
+          VER="${LIBLSL_VERSION}"
+          if [[ "$CODENAME" == "noble" ]]; then
+            ASSET="liblsl-${VER}-noble_amd64.tar.gz"
+          else
+            ASSET="liblsl-${VER}-jammy_amd64.tar.gz"
+          fi
+
+          curl -L -o liblsl.tgz "https://github.com/sccn/liblsl/releases/download/v${VER}/${ASSET}"
+          mkdir -p "$GITHUB_WORKSPACE/liblsl"
+          tar -xzf liblsl.tgz -C "$GITHUB_WORKSPACE/liblsl"
+
+          echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/liblsl/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+
+      - name: Install liblsl (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          VER="${LIBLSL_VERSION}"
+          ASSET="liblsl-1.17-Darwin-universal.pkg"
+
+          curl -L -o liblsl.pkg "https://github.com/sccn/liblsl/releases/download/v${VER}/${ASSET}"
+          sudo installer -pkg liblsl.pkg -target /
+
+          echo "DYLD_LIBRARY_PATH=/usr/local/lib:${DYLD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+
+      - name: Install liblsl (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ver = $env:LIBLSL_VERSION
+          $asset = "liblsl-$ver-Win_amd64.zip"
+          $url = "https://github.com/sccn/liblsl/releases/download/v$ver/$asset"
+
+          Invoke-WebRequest -Uri $url -OutFile "liblsl.zip"
+          Expand-Archive -Path "liblsl.zip" -DestinationPath "$env:GITHUB_WORKSPACE\liblsl" -Force
+
+          $p1 = "$env:GITHUB_WORKSPACE\liblsl\bin"
+          $p2 = "$env:GITHUB_WORKSPACE\liblsl\lib"
+          $p3 = "$env:GITHUB_WORKSPACE\liblsl"
+          "PATH=$p1;$p2;$p3;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Lint with flake8
+        shell: bash
+        run: |
+          set -euxo pipefail
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test with pytest
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,7 +37,7 @@ jobs:
           set -euxo pipefail
           python -m pip install --upgrade pip
           python -m pip install flake8 pytest
-          if [ -f tests_requirements.txt ]; then python -m pip install -r tests_requirements.txt; fi
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
 
       - name: Install liblsl (Linux)
         if: runner.os == 'Linux'
@@ -87,6 +87,18 @@ jobs:
           $p2 = "$env:GITHUB_WORKSPACE\liblsl\lib"
           $p3 = "$env:GITHUB_WORKSPACE\liblsl"
           "PATH=$p1;$p2;$p3;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Checkout dp-mockup-streamer (for tests)
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/bsdlab/dp-mockup-streamer.git external/dp-mockup-streamer
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/external/dp-mockup-streamer:${PYTHONPATH:-}" >> "$GITHUB_ENV"
+
+      - name: Checkout dp-passthrough (for tests)
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/bsdlab/dp-passthrough.git external/dp-passthrough
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/external/dp-passthrough:${PYTHONPATH:-}" >> "$GITHUB_ENV"
 
       - name: Lint with flake8
         shell: bash

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -104,8 +104,8 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=external
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=external
 
       - name: Test with pytest
         shell: bash

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-dp-mockup-streamer @ git@github.com:bsdlab/dp-mockup-streamer.git
-dp-passthrough @ git@github.com:bsdlab/dp-passthrough.git
+dp-mockup-streamer @ git+https://github.com/bsdlab/dp-mockup-streamer.git
+dp-passthrough @ git+https://github.com/bsdlab/dp-passthrough.git
 pytest

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,4 +1,0 @@
--r requirements.txt
-dp-mockup-streamer @ git+https://github.com/bsdlab/dp-mockup-streamer.git
-dp-passthrough @ git+https://github.com/bsdlab/dp-passthrough.git
-pytest

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+dp-mockup-streamer @ git@github.com:bsdlab/dp-mockup-streamer.git
+dp-passthrough @ git@github.com:bsdlab/dp-passthrough.git
+pytest


### PR DESCRIPTION
Adds a github workflow to automatically run the control-room test suite when creating a PR into main. Tests are run on `ubuntu-latest`, `macos-latest`, `windows-latest` and Python versions `3.11`, `3.12`, `3.13`, and `3.14`. 

This includes:
- Downloading liblsl (pinned to version 1.17.5)
- Pulling other dp modules used in tests (dp-passthrough, dp-mockup-streamer)
- installing dependencies
- running a linter to check for syntax errors
- running pytest